### PR TITLE
Add Map Pin filter for maximum amount of pets

### DIFF
--- a/Modules/Config/ConfigModule.lua
+++ b/Modules/Config/ConfigModule.lua
@@ -103,6 +103,7 @@ local options = {
                 T1ALL = "All",
                 T2MISSING = "Missing",
                 T3NOTRARE = "Not Rare",
+                T5NOTMAXCOLLECTED = "Not maximum amount collected",
                 T4NONE = "None"
             },
             get = function()

--- a/Modules/Data/DataModule.lua
+++ b/Modules/Data/DataModule.lua
@@ -68,6 +68,11 @@ function DataModule:ShouldPetBeShown(speciesId)
                     return false
                 end
             end
+
+            if ConfigModule.AceDB.profile.mapPinsToInclude == "T5NOTMAXCOLLECTED" then
+                numCollected, limit = C_PetJournal.GetNumCollectedInfo(speciesId)
+                return numCollected < limit;
+            end
         end
     end
 


### PR DESCRIPTION
Hey there :) I'd like to provide a small feature extension that I've been using for myself.

The added filter only shows pets that the player hasn't collected the respective maximum amount of.