### PR TITLE
Update CanWeCapturePets to take unobtainable pets into account

### DIFF
--- a/Modules/Data/DataModule.lua
+++ b/Modules/Data/DataModule.lua
@@ -127,12 +127,16 @@ function DataModule:GetEnemyPetsInBattle()
     for i = 1, numberOfEnemyPets do
         local speciesId = C_PetBattles.GetPetSpeciesID(Enum.BattlePetOwner.Enemy, i)
         local breedQuality = C_PetBattles.GetBreedQuality(Enum.BattlePetOwner.Enemy, i)
-        local ownedPets = DataModule:GetOwnedPets(speciesId)
+        local obtainable = select(11, C_PetJournal.GetPetInfoBySpeciesID(speciesId));
 
-        if (ownedPets == nil) then
-            table.insert(foundNotOwnedPets, { speciesId, breedQuality })
-        else
-            table.insert(foundOwnedPets, { speciesId, breedQuality })
+        if obtainable then
+            local ownedPets = DataModule:GetOwnedPets(speciesId)
+
+            if (ownedPets == nil) then
+                table.insert(foundNotOwnedPets, { speciesId, breedQuality })
+            else
+                table.insert(foundOwnedPets, { speciesId, breedQuality })
+            end
         end
     end
 


### PR DESCRIPTION
There are some non-NPC battles that include non-captureable pets. One example of this is the Tiny Terrors in Tanaan legendary pets. Currently, upon entering such a battle, you get a "Uncollected pet found!" dialog. This change attempts to exclude the unobtainable pet(s) from consideration, while still allowing normal processing of other pets in the battle for capture/upgrade.