### PR TITLE
Improve broker handling of zone changes

### DIFF
--- a/Modules/Broker/BrokerModule.lua
+++ b/Modules/Broker/BrokerModule.lua
@@ -30,7 +30,11 @@ function BrokerModule:GetDataObject()
 end
 
 function BrokerModule:RegisterEventHandlers()
+    self:RegisterEvent("ZONE_CHANGED", "RefreshData")
+    self:RegisterEvent("ZONE_CHANGED_INDOORS", "RefreshData")
     self:RegisterEvent("ZONE_CHANGED_NEW_AREA", "RefreshData")
+    self:RegisterEvent("NEW_WMO_CHUNK", "RefreshData")
+    self:RegisterEvent("PLAYER_ENTERING_WORLD", "RefreshData")
     LibPetJournal.RegisterCallback(self, "PetListUpdated", "RefreshData")
 end
 


### PR DESCRIPTION
Fixes #26 

I did a bit more testing, and it was reliably reproducible when entering/leaving Chitterspine Grotto.  The issue is that the zone change events fire a bit earlier than the return value for `C_Map.GetBestMapForUnit("player")` changes, so by the time the best map changes, we already processed the event.  Adding an event registration for NEW_WMO_CHUNK fixes that.  I don't know exactly what that event is, but it seems to be used alongside the other zone change events in a number of places, and appears to fix the behavior.  The new list of events used is based on comparison with a few other plugins that do things based on zone changes.