### PR TITLE
Fix for C_PetBattles.GetBreedQuality being indexed from 0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 11.0.0-20240725-1
+* Fix for C_PetBattles.GetBreedQuality being indexed from 0 (used to be 1).
+
 # 11.0.0-20240723-1
 * Updated Ace3 to support The War Within.
 * Comment out map dropdown, since the logic is not compatible with The War Within.

--- a/Modules/Data/DataModule.lua
+++ b/Modules/Data/DataModule.lua
@@ -143,6 +143,11 @@ function DataModule:GetEnemyPetsInBattle()
         local breedQuality = C_PetBattles.GetBreedQuality(Enum.BattlePetOwner.Enemy, i)
         local obtainable = select(11, C_PetJournal.GetPetInfoBySpeciesID(speciesId));
 
+        -- In 11.0.0, Blizzard changed the C_PetBattles.GetBreedQuality to be indexed from 0.
+        -- However, all other functions related to pet quality is still indexed from 1.
+        -- So until everything is changed, we just add 1 to the result.
+        breedQuality = breedQuality + 1
+
         if obtainable then
             local ownedPets = DataModule:GetOwnedPets(speciesId)
 


### PR DESCRIPTION
In 11.0.0, Blizzard changed the [C_PetBattles.GetBreedQuality](https://wowpedia.fandom.com/wiki/API_C_PetBattles.GetBreedQuality) to be indexed from 0.
However, all other functions related to pet quality is still indexed from 1.
So until everything is changed, we just add 1 to the result.