### PR TITLE
Added support for toggling map pins using chat command

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 11.0.2-20240821-2
+* Added support for toggling map pins using chat command.
+
 # 11.0.2-20240821-1
 * Right click on broker plug-in fix, provided by davidmc24 on github.
 * Fix goal tracker toggle window behavior, provided by davidmc24 on github.

--- a/Modules/Map/MapModule.lua
+++ b/Modules/Map/MapModule.lua
@@ -18,7 +18,7 @@
 
 local addonName, _ = ...
 local BattlePetCompletionist = LibStub("AceAddon-3.0"):GetAddon(addonName)
-local MapModule = BattlePetCompletionist:NewModule("MapModule")
+local MapModule = BattlePetCompletionist:NewModule("MapModule", "AceConsole-3.0")
 local DataModule = BattlePetCompletionist:GetModule("DataModule")
 local DBModule = BattlePetCompletionist:GetModule("DBModule")
 local AceHook = LibStub("AceHook-3.0")
@@ -185,13 +185,15 @@ function MapModule:UpdateWorldMap()
     MapModule.WorldMapDataProvider:RefreshAllData()
 end
 
-local function BattlePetToggle_OnClick()
+function MapModule:BattlePetToggle_OnClick()
     local profile = DBModule:GetProfile()
     if profile.mapPinsToInclude == _BattlePetCompletionist.Enums.MapPinFilter.NONE then
         profile.mapPinsToInclude = profile.mapPinsToIncludeOriginal
+        MapModule:Print("Battle Pet Completionist - Tracking enabled.")
     else
         profile.mapPinsToIncludeOriginal = profile.mapPinsToInclude
         profile.mapPinsToInclude = _BattlePetCompletionist.Enums.MapPinFilter.NONE
+        MapModule:Print("Battle Pet Completionist - Tracking disabled.")
     end
 
     MapModule:UpdateWorldMap()
@@ -212,7 +214,7 @@ function MapModule:InitializeDropDown()
 --        battlePetToggle.keepShownOnClick = true
 --        battlePetToggle.text = "Battle Pets"
 --        battlePetToggle.checked = DBModule:GetProfile().mapPinsToInclude ~= _BattlePetCompletionist.Enums.MapPinFilter.NONE
---        battlePetToggle.func = BattlePetToggle_OnClick
+--        battlePetToggle.func = MapModule.BattlePetToggle_OnClick
 --        UIDropDownMenu_AddButton(battlePetToggle)
 --    end)
 end
@@ -239,4 +241,8 @@ function MapModule:GetMapPinScale()
     }
 
     return scaleMap[DBModule:GetProfile().mapPinSize]
+end
+
+function MapModule:OnInitialize()
+    MapModule:RegisterChatCommand("bpcom-toggle", "BattlePetToggle_OnClick")
 end


### PR DESCRIPTION
This fixes #43 by adding support for toggling map pins using the chat command: `/bpcom-toggle`