### PR TITLE
Objective tracker fix

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,7 +19,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install subversion
 
-      - name: Create Package
+      - name: Create Retail Package
         uses: BigWigsMods/packager@v2
+        with:
+          args: -g retail
+        env:
+          CF_API_KEY: ${{ secrets.CURSEFORGE_API_TOKEN }}
+
+      - name: Create Classic Package
+        uses: BigWigsMods/packager@v2
+        with:
+          args: -g mists
         env:
           CF_API_KEY: ${{ secrets.CURSEFORGE_API_TOKEN }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # 11.2.0-20250921-1
 * Exclude objective tracker code from Classic until it can be fixed.
+* Changed to use separate builds for Retail and Classic.
 
 # 11.2.0-20250920-1
 * Fix bug when Kaliel's Tracker is not installed or loaded.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 11.2.0-20250921-1
+* Exclude objective tracker code from Classic until it can be fixed.
+
 # 11.2.0-20250920-1
 * Fix bug when Kaliel's Tracker is not installed or loaded.
 

--- a/Modules/Config/ConfigModule.lua
+++ b/Modules/Config/ConfigModule.lua
@@ -407,6 +407,7 @@ local options = {
                 profile.notifyForRareUpgrade = not profile.notifyForRareUpgrade
             end
         },
+--@retail@
         objectiveTrackerHeader = {
             order = 31,
             name = L["Header - Objective Tracker"],
@@ -459,6 +460,7 @@ local options = {
                 ObjectiveTrackerModule:OnEvent("CONFIG_CHANGED")
             end
         }
+--@end-retail@
     },
 }
 

--- a/Modules/modules.xml
+++ b/Modules/modules.xml
@@ -13,5 +13,7 @@
     <Include file="AddonCompartment\AddonCompartmentModule.xml"/>
     <Include file="Minimap\MinimapModule.xml"/>
     <Include file="Tooltip\TooltipModule.xml"/>
+    <!--@retail@-->
     <Include file="ObjectiveTracker\ObjectiveTrackerModule.xml"/>
+    <!--@end-retail@-->
 </Ui>


### PR DESCRIPTION
* Exclude objective tracker code from Classic until it can be fixed.
* Changed to use separate builds for Retail and Classic.