### PR TITLE
Taint Prevention (Cleaned up & updated version of #139)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 12.0.7-20260713-1
+* Multiple fixes for taint issues, patches provided by JPEscher on github.
+
 # 12.0.7-20260617-1
 * Updated TOC to match 12.0.7
 

--- a/Modules/Broker/BrokerModule.lua
+++ b/Modules/Broker/BrokerModule.lua
@@ -85,6 +85,7 @@ function BrokerModule:OnInitialize()
 end
 
 function BrokerModule:QualityToColorCode(quality)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(quality) then return "" end end
     if quality and quality >= 1 then
         return ITEM_QUALITY_COLORS[quality - 1].hex
     else
@@ -93,6 +94,7 @@ function BrokerModule:QualityToColorCode(quality)
 end
 
 function BrokerModule:TooltipToSourceTypeIcon(speciesId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return "" end end
     local sourceType = DataModule:GetPetSource(speciesId)
 
     return _BattlePetCompletionist.Constants.PET_SOURCE_ICONS[sourceType] or _BattlePetCompletionist.Constants.PET_SOURCE_ICON_FALLBACK
@@ -100,6 +102,7 @@ end
 
 -- Also used by AddonCompartmentModule
 function BrokerModule:OnTooltipShow(tooltip, includeDetails)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(tooltip) or issecretvalue(includeDetails) then return end end
     tooltip:AddLine(L["Battle Pet Completionist"])
     tooltip:AddLine(L["Left Click to toggle goal tracker"])
     tooltip:AddLine(L["Right Click for options"])
@@ -151,6 +154,7 @@ end
 
 -- Also used by AddonCompartmentModule
 function BrokerModule:OnClick(button)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(button) then return end end
     if button == "LeftButton" then
         GoalTrackerModule:ToggleWindow()
     elseif button == "RightButton" then
@@ -178,10 +182,12 @@ local goalSuffixes = {
 }
 
 function BrokerModule:GetSuffixForGoal(goal)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(goal) then return "" end end
     return goalSuffixes[goal] or ""
 end
 
 function BrokerModule:MetGoal(goal, numCollected, numRareCollected, limit)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(goal) or issecretvalue(numCollected) or issecretvalue(numRareCollected) or issecretvalue(limit) then return false end end
     if goal == _BattlePetCompletionist.Enums.Goal.COLLECT then
         return numCollected > 0
     elseif goal == _BattlePetCompletionist.Enums.Goal.COLLECT_RARE then
@@ -196,6 +202,7 @@ function BrokerModule:MetGoal(goal, numCollected, numRareCollected, limit)
 end
 
 function BrokerModule:GetNumCollectedInfo(speciesId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return 0, 0, 0 end end
     local numCollected, limit = C_PetJournal.GetNumCollectedInfo(speciesId)
     local myPets = DataModule:GetOwnedPets(speciesId) or {}
     local numRareCollected = 0

--- a/Modules/Combat/CombatModule.lua
+++ b/Modules/Combat/CombatModule.lua
@@ -39,6 +39,7 @@ local myName
 
 function CombatModule:OnEnable()
     myName = UnitName("player")
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(myName) then return end end
     self:RegisterEvent("PET_BATTLE_OPENING_START", "BattleHasStarted")
 
     self:RegisterComm(messagePrefixes.ANNOUNCE_PETS, "HaFOnReceivedAnnounce")
@@ -50,6 +51,7 @@ end
 
 local function CanWeFindPlayerPosition()
     local mapId = C_Map.GetBestMapForUnit("player")
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapId) then return false end end
 
     if not mapId then
         return false

--- a/Modules/DB/DBModule.lua
+++ b/Modules/DB/DBModule.lua
@@ -100,6 +100,7 @@ function DBModule:InvalidateMapPinSourcesCache()
 end
 
 local function dataVersion(profile)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(profile) then return 0 end end
     return profile.dataVersion or 0
 end
 

--- a/Modules/Data/DataModule.lua
+++ b/Modules/Data/DataModule.lua
@@ -44,6 +44,7 @@ function DataModule:HasAnyDataLoaded()
 end
 
 local function DoesPetMatchSourceFilters(speciesId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return false end end
     local petSource = DataModule:GetPetSource(speciesId)
 
     if petSource == ZONE then
@@ -64,6 +65,7 @@ local function DoesPetMatchSourceFilters(speciesId)
 end
 
 local function GetMapZoneNames(mapId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapId) then return {} end end
     local info = C_Map.GetMapInfo(mapId)
 
     if not info or info.mapType == Enum.UIMapType.Dungeon then
@@ -88,6 +90,7 @@ local function GetMapZoneNames(mapId)
 end
 
 local function IsPetInMapZone(speciesId, mapZoneNames)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) or issecretvalue(mapZoneNames) then return false end end
     local petSource = DataModule:GetPetSource(speciesId)
 
     -- Only filter by source if the pet source is Zone or Pet Battle.
@@ -120,6 +123,7 @@ local function IsPetInMapZone(speciesId, mapZoneNames)
 end
 
 function DataModule:GetPetsInMap(mapId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapId) then return end end
     local allPets = DataModule.PetData[mapId]
     if not allPets then
         return nil
@@ -138,6 +142,7 @@ function DataModule:GetPetsInMap(mapId)
 end
 
 function DataModule:ShouldPetBeShown(speciesId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return false end end
     -- Apply source filters first so that later settings can't forget to take them into account
     if not DoesPetMatchSourceFilters(speciesId) then
         return false
@@ -211,6 +216,7 @@ function DataModule:ShouldPetBeShown(speciesId)
 end
 
 function DataModule:GetOwnedPets(speciesId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return end end
     local ownedPets = {}
     local anyPetsFound = false
 
@@ -234,6 +240,7 @@ end
 
 function DataModule:GetEnemyPetsInBattle()
     local numberOfEnemyPets = C_PetBattles.GetNumPets(Enum.BattlePetOwner.Enemy)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(numberOfEnemyPets) then return {}, {} end end
     local foundNotOwnedPets = {}
     local foundOwnedPets = {}
 
@@ -263,6 +270,7 @@ end
 
 function DataModule:CanWeCapturePets()
     local isNpcControlled = C_PetBattles.IsPlayerNPC(Enum.BattlePetOwner.Enemy)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(isNpcControlled) then return false end end
 
     if isNpcControlled == false then
         -- It is a PvP pet battle, you cannot capture pets here.
@@ -292,6 +300,7 @@ function DataModule:CanWeCapturePets()
 end
 
 function DataModule:GetPetSource(speciesId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return end end
     local function cleanColorTags(text)
         if not text then return nil end
         return text:gsub("|c%x%x%x%x%x%x%x%x", ""):gsub("|r", "")

--- a/Modules/GoalTracker/GoalTrackerModule.lua
+++ b/Modules/GoalTracker/GoalTrackerModule.lua
@@ -35,6 +35,7 @@ function GoalTrackerModule:UpdateWindow()
     local entries = {}
     if petData then
         for speciesId, _ in pairs(petData) do
+            if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return end end
             local numCollected = C_PetJournal.GetNumCollectedInfo(speciesId)
             totalSpeciesCount = totalSpeciesCount + 1
 
@@ -179,6 +180,7 @@ function GoalTrackerModule:GetZonePetData()
 end
 
 function GoalTrackerModule:TooltipToSourceTypeIcon(speciesId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return "" end end
     local sourceType = DataModule:GetPetSource(speciesId)
 
     return _BattlePetCompletionist.Constants.PET_SOURCE_ICONS[sourceType] or _BattlePetCompletionist.Constants.PET_SOURCE_ICON_FALLBACK

--- a/Modules/Map/MapModule.lua
+++ b/Modules/Map/MapModule.lua
@@ -27,6 +27,7 @@ local L = LibStub("AceLocale-3.0"):GetLocale(addonName .. "_Map")
 MapModule.WorldMapDataProvider = CreateFromMixins(MapCanvasDataProviderMixin)
 
 function MapModule.WorldMapDataProvider:OnCanvasScaleChanged()
+    if InCombatLockdown() then return end
     local map = self:GetMap()
     if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(map) then return end end
 
@@ -50,6 +51,7 @@ function MapModule.WorldMapDataProvider:RemoveAllData()
 end
 
 function MapModule.WorldMapDataProvider:RefreshAllData()
+    if InCombatLockdown() then return end
     if not self:GetMap() then
         return
     end
@@ -166,6 +168,7 @@ function BattlePetCompletionistWorldMapPinMixin:OnAcquired(x, y, iconpath)
 end
 
 function BattlePetCompletionistWorldMapPinMixin:ShowPinTooltip()
+    if InCombatLockdown() then return end
     if not self:IsMouseOver() then
         return
     end
@@ -203,6 +206,7 @@ end
 function BattlePetCompletionistWorldMapPinMixin:OnMouseEnter()
     -- Defer to the next frame to break the taint chain between addon code
     -- and Blizzard's tooltip/MoneyFrame rendering (see issue #134).
+    if InCombatLockdown() then return end
     C_Timer.After(0, function() self:ShowPinTooltip() end)
 end
 
@@ -211,6 +215,7 @@ function BattlePetCompletionistWorldMapPinMixin:OnMouseLeave()
 end
 
 function BattlePetCompletionistWorldMapPinMixin:OnMouseClickAction(button)
+    if InCombatLockdown() then return end
     if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(button) then return end end
     if button ~= "LeftButton" then
         return

--- a/Modules/Map/MapModule.lua
+++ b/Modules/Map/MapModule.lua
@@ -28,6 +28,7 @@ MapModule.WorldMapDataProvider = CreateFromMixins(MapCanvasDataProviderMixin)
 
 function MapModule.WorldMapDataProvider:OnCanvasScaleChanged()
     local map = self:GetMap()
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(map) then return end end
 
     if not map then
         return
@@ -76,6 +77,7 @@ function MapModule.WorldMapDataProvider:RefreshAllData()
 end
 
 function MapModule.WorldMapDataProvider:LoadMapData(mapId)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapId) then return end end
     self:BeginPinAllocation()
 
     if not self:GetMap() then
@@ -89,6 +91,7 @@ function MapModule.WorldMapDataProvider:LoadMapData(mapId)
     end
 
     local function IsTooCloseToExistingPin(placedPositions, x, y, threshold)
+        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(x) or issecretvalue(y) or issecretvalue(threshold) then return false end end
         for _, pos in ipairs(placedPositions) do
             if math.abs(pos[1] - x) < threshold and math.abs(pos[2] - y) < threshold then
                 return true
@@ -107,6 +110,7 @@ function MapModule.WorldMapDataProvider:LoadMapData(mapId)
     end
 
     local function GetMapZoomPercent(map)
+        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(map) then return 0 end end
         if not map or not map.ScrollContainer or not map.ScrollContainer.HasZoomLevels or not map.GetCanvasZoomPercent then
             return 0
         end
@@ -167,6 +171,7 @@ function BattlePetCompletionistWorldMapPinMixin:ShowPinTooltip()
     end
 
     local speciesName, speciesIcon, _, _, tooltipSource = C_PetJournal.GetPetInfoBySpeciesID(self.PetSpeciesID)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesName) or issecretvalue(speciesIcon) or issecretvalue(tooltipSource) then return end end
 
     local ownedPets = DataModule:GetOwnedPets(self.PetSpeciesID)
 
@@ -206,6 +211,7 @@ function BattlePetCompletionistWorldMapPinMixin:OnMouseLeave()
 end
 
 function BattlePetCompletionistWorldMapPinMixin:OnMouseClickAction(button)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(button) then return end end
     if button ~= "LeftButton" then
         return
     end

--- a/Modules/Map/MapTooltip.lua
+++ b/Modules/Map/MapTooltip.lua
@@ -136,11 +136,13 @@ do
             totalHeight = headerLineHeight + (lineCount - 1) * normalLineHeight + 2 + TOOLTIP_PADDING
         end
 
-        BPCMapTooltip:SetWidth(tooltipWidth)
-        BPCMapTooltip:SetHeight(totalHeight)
-        BPCMapTooltip:ClearAllPoints()
-        BPCMapTooltip:SetPoint("TOPLEFT", anchor, "TOPRIGHT", 10, 0)
-        BPCMapTooltip:Show()
+        local finalOk, _ = pcall(function()
+            BPCMapTooltip:SetWidth(tooltipWidth)
+            BPCMapTooltip:SetHeight(totalHeight)
+            BPCMapTooltip:ClearAllPoints()
+            BPCMapTooltip:SetPoint("TOPLEFT", anchor, "TOPRIGHT", 10, 0)
+            BPCMapTooltip:Show()
+        end)
     end
 
     function MapModule:Tooltip_Hide()

--- a/Modules/Map/MapTooltip.lua
+++ b/Modules/Map/MapTooltip.lua
@@ -43,6 +43,8 @@ do
     end
 
     function MapModule.Tooltip_Show(anchor, headerLine, collectedLine, sourceLine)
+        if InCombatLockdown() then return end
+        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(anchor) or issecretvalue(headerLine) or issecretvalue(collectedLine) or issecretvalue(sourceLine) then return end end
         EnsureFontCached()
 
         if not mapTooltipHeaderFont then
@@ -146,6 +148,7 @@ do
     end
 
     function MapModule.WrapTextWithColor(color, text)
+        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(color) or issecretvalue(text) then return "" end end
         if not color or text == nil then
             return text
         end

--- a/Modules/ObjectiveTracker/ObjectiveTrackerModule.lua
+++ b/Modules/ObjectiveTracker/ObjectiveTrackerModule.lua
@@ -25,6 +25,7 @@ local ZoneModule = BattlePetCompletionist:GetModule("ZoneModule")
 
 -- Sorts by speciesName alphabetically, falling back to speciesId for unnamed entries.
 local function ComparePetsByName(a, b)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(a) or issecretvalue(b) then return false end end
     if a.speciesName and b.speciesName then
         return a.speciesName < b.speciesName
     elseif a.speciesName then
@@ -57,6 +58,7 @@ function ObjectiveTrackerModule:GetFilteredPetList()
     local anyMissing = false
     local allPets = {}
     for speciesId in pairs(pets) do
+        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return end end
         local numCollected = C_PetJournal.GetNumCollectedInfo(speciesId)
         if numCollected == 0 then
             anyMissing = true

--- a/Modules/ObjectiveTracker/ObjectiveTrackerModule_Retail.lua
+++ b/Modules/ObjectiveTracker/ObjectiveTrackerModule_Retail.lua
@@ -39,10 +39,12 @@ function BattlePetCompletionistObjectiveTrackerMixin:InitModule()
 end
 
 function BattlePetCompletionistObjectiveTrackerMixin:OnEvent(event, ...)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(event) then return end end
     self:MarkDirty()
 end
 
 function BattlePetCompletionistObjectiveTrackerMixin:OnBlockHeaderClick(block, mouseButton)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(block) or issecretvalue(mouseButton) then return end end
     if mouseButton == "LeftButton" then
         if not CollectionsJournal or not CollectionsJournal:IsShown() then
             ToggleCollectionsJournal()
@@ -54,6 +56,7 @@ end
 
 function BattlePetCompletionistObjectiveTrackerMixin:LayoutContents()
     local filteredPets, mapID = ObjectiveTrackerModule:GetFilteredPetList()
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(filteredPets) or issecretvalue(mapID) then return end end
     if not filteredPets then
         return
     end
@@ -72,6 +75,7 @@ function BattlePetCompletionistObjectiveTrackerMixin:LayoutContents()
 end
 
 function BattlePetCompletionistObjectiveTrackerMixin:AddBattlePet(block, petInfo)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(petInfo) or issecretvalue(block) then return end end
     if not petInfo.speciesName then
         return
     end
@@ -121,6 +125,7 @@ do
     end
 
     function ObjectiveTrackerModule:OnPetEvent(event, ...)
+        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(event) then return end end
         if self.Mixin then
             self.Mixin:OnEvent(event, ...)
         end

--- a/Modules/Tooltip/TooltipModule.lua
+++ b/Modules/Tooltip/TooltipModule.lua
@@ -22,6 +22,7 @@ local DBModule = BattlePetCompletionist:GetModule("DBModule")
 local TooltipModule = BattlePetCompletionist:NewModule("TooltipModule")
 
 function TooltipModule:OnEnable()
+    if InCombatLockdown() then return end
     hooksecurefunc("BattlePetToolTip_Show", function(speciesID, ...)
         if DBModule:IsPetCageTooltipEnabled() then
             C_Timer.After(0, function()
@@ -34,6 +35,7 @@ function TooltipModule:OnEnable()
 end
 
 function TooltipModule.ModifyPetTip(speciesID)
+    if InCombatLockdown() then return end
     if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesID) then return end end
     local _, _, _, _, source = C_PetJournal.GetPetInfoBySpeciesID(speciesID)
     if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(source) then return end end

--- a/Modules/Tooltip/TooltipModule.lua
+++ b/Modules/Tooltip/TooltipModule.lua
@@ -34,7 +34,9 @@ function TooltipModule:OnEnable()
 end
 
 function TooltipModule.ModifyPetTip(speciesID)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesID) then return end end
     local _, _, _, _, source = C_PetJournal.GetPetInfoBySpeciesID(speciesID)
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(source) then return end end
 
     if source and source ~= "" then
         BattlePetTooltip:AddLine(" ", 1, 1, 1, false)

--- a/Modules/Tooltip/TooltipModule.lua
+++ b/Modules/Tooltip/TooltipModule.lua
@@ -22,7 +22,6 @@ local DBModule = BattlePetCompletionist:GetModule("DBModule")
 local TooltipModule = BattlePetCompletionist:NewModule("TooltipModule")
 
 function TooltipModule:OnEnable()
-    if InCombatLockdown() then return end
     hooksecurefunc("BattlePetToolTip_Show", function(speciesID, ...)
         if DBModule:IsPetCageTooltipEnabled() then
             C_Timer.After(0, function()

--- a/Modules/Zone/ZoneModule.lua
+++ b/Modules/Zone/ZoneModule.lua
@@ -40,6 +40,7 @@ function ZoneModule:ResolveZone()
     -- If we wanted to exclude certain sub-zones from being eligible for selection, we could do so using data from
     -- C_Map.GetMapInfo, such as parentMapID.  However, this appears sufficient for now.
     local mapID = C_Map.GetBestMapForUnit("player")
+    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapID) then return end end
     -- self.mapID will be nil on first check
     if mapID ~= self.mapID then
         self.mapID = mapID


### PR DESCRIPTION
# Changes in Pull Request
- [x] added "if retail then if issecret" skips to prevent tainting
- [x] added new pcall to prevent tainting
- [x] added some InCombatLockdown checks to prevent tainting due to combat
    - this needs @GurliGebis to review. should they be wrapped in "if retail then" and do they have correct returns?
        - according to [WoW Wiki API Page for InCombatLockdown](https://warcraft.wiki.gg/wiki/API_InCombatLockdown) this is in all versions

these prevent unintentional tainting when blizzard calls and this mod filters

# Issues Looked At & [Possibly] Addressed
- [x] tried to address #103
- [x] tried to address #108
- [x] tried to address #135
- [x] addressed #138
- [x] addressed #140
- [x] addressed #142

# Thread for Testing these Changes
- "Alpha Testing Instructions" #142 

# Notes on PR
- i did not do this to be an additional author, but rather to expedite taint prevention and make my gameplay smoother as i like this mod and what it adds
- This one was created due to the mess #139 became. #139 is closed without merging as a result.
- This one grabs the 12.0.7 toc update