### PR TITLE
Corruption prevention update

### DIFF
--- a/Modules/Broker/BrokerModule.lua
+++ b/Modules/Broker/BrokerModule.lua
@@ -85,7 +85,10 @@ function BrokerModule:OnInitialize()
 end
 
 function BrokerModule:QualityToColorCode(quality)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(quality) then return "" end end
+    if issecretvalue and issecretvalue(quality) then
+        return ""
+    end
+
     if quality and quality >= 1 then
         return ITEM_QUALITY_COLORS[quality - 1].hex
     else
@@ -94,7 +97,10 @@ function BrokerModule:QualityToColorCode(quality)
 end
 
 function BrokerModule:TooltipToSourceTypeIcon(speciesId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return "" end end
+    if issecretvalue and issecretvalue(speciesId) then
+        return ""
+    end
+
     local sourceType = DataModule:GetPetSource(speciesId)
 
     return _BattlePetCompletionist.Constants.PET_SOURCE_ICONS[sourceType] or _BattlePetCompletionist.Constants.PET_SOURCE_ICON_FALLBACK
@@ -102,7 +108,10 @@ end
 
 -- Also used by AddonCompartmentModule
 function BrokerModule:OnTooltipShow(tooltip, includeDetails)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(tooltip) or issecretvalue(includeDetails) then return end end
+    if issecretvalue and (issecretvalue(tooltip) or issecretvalue(includeDetails)) then
+        return
+    end
+
     tooltip:AddLine(L["Battle Pet Completionist"])
     tooltip:AddLine(L["Left Click to toggle goal tracker"])
     tooltip:AddLine(L["Right Click for options"])
@@ -125,6 +134,11 @@ function BrokerModule:OnTooltipShow(tooltip, includeDetails)
             metGoalCount = metGoalCount + 1
         else
             local speciesName, speciesIcon = C_PetJournal.GetPetInfoBySpeciesID(speciesId)
+
+            if issecretvalue and (issecretvalue(speciesName) or issecretvalue(speciesIcon)) then
+                return
+            end
+
             local myPets = DataModule:GetOwnedPets(speciesId) or {}
             local petStrings = {}
             for _, myPetInfo in ipairs(myPets) do
@@ -154,7 +168,10 @@ end
 
 -- Also used by AddonCompartmentModule
 function BrokerModule:OnClick(button)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(button) then return end end
+    if issecretvalue and issecretvalue(button) then
+        return
+    end
+
     if button == "LeftButton" then
         GoalTrackerModule:ToggleWindow()
     elseif button == "RightButton" then
@@ -182,12 +199,18 @@ local goalSuffixes = {
 }
 
 function BrokerModule:GetSuffixForGoal(goal)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(goal) then return "" end end
+    if issecretvalue and issecretvalue(goal) then
+        return ""
+    end
+
     return goalSuffixes[goal] or ""
 end
 
 function BrokerModule:MetGoal(goal, numCollected, numRareCollected, limit)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(goal) or issecretvalue(numCollected) or issecretvalue(numRareCollected) or issecretvalue(limit) then return false end end
+    if issecretvalue and (issecretvalue(goal) or issecretvalue(numCollected) or issecretvalue(numRareCollected) or issecretvalue(limit)) then
+        return false
+    end
+
     if goal == _BattlePetCompletionist.Enums.Goal.COLLECT then
         return numCollected > 0
     elseif goal == _BattlePetCompletionist.Enums.Goal.COLLECT_RARE then
@@ -202,8 +225,16 @@ function BrokerModule:MetGoal(goal, numCollected, numRareCollected, limit)
 end
 
 function BrokerModule:GetNumCollectedInfo(speciesId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return 0, 0, 0 end end
+    if issecretvalue and issecretvalue(speciesId) then
+        return 0, 0, 0
+    end
+
     local numCollected, limit = C_PetJournal.GetNumCollectedInfo(speciesId)
+
+    if issecretvalue and (issecretvalue(numCollected) or issecretvalue(limit)) then
+        return 0, 0, 0
+    end
+
     local myPets = DataModule:GetOwnedPets(speciesId) or {}
     local numRareCollected = 0
     for _, myPetInfo in ipairs(myPets) do

--- a/Modules/Capture/CaptureModule.lua
+++ b/Modules/Capture/CaptureModule.lua
@@ -98,6 +98,11 @@ function CaptureModule:CreatePetsDialog(pets, mode)
 
         if i <= #pets then
             local speciesName, speciesIcon = C_PetJournal.GetPetInfoBySpeciesID(pets[i][1])
+
+            if issecretvalue and (issecretvalue(speciesName) or issecretvalue(speciesIcon)) then
+                return
+            end
+
             local color = ITEM_QUALITY_COLORS[pets[i][2] - 1].hex
             icon:SetTexture(speciesIcon)
             label:SetText(color .. speciesName .. "|r")

--- a/Modules/Combat/CombatModule.lua
+++ b/Modules/Combat/CombatModule.lua
@@ -39,7 +39,11 @@ local myName
 
 function CombatModule:OnEnable()
     myName = UnitName("player")
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(myName) then return end end
+
+    if issecretvalue and issecretvalue(myName) then
+        return
+    end
+
     self:RegisterEvent("PET_BATTLE_OPENING_START", "BattleHasStarted")
 
     self:RegisterComm(messagePrefixes.ANNOUNCE_PETS, "HaFOnReceivedAnnounce")
@@ -51,13 +55,20 @@ end
 
 local function CanWeFindPlayerPosition()
     local mapId = C_Map.GetBestMapForUnit("player")
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapId) then return false end end
+
+    if issecretvalue and issecretvalue(mapId) then
+        return false
+    end
 
     if not mapId then
         return false
     end
 
     local position = C_Map.GetPlayerMapPosition(mapId, "player")
+
+    if issecretvalue and issecretvalue(position) then
+        return false
+    end
 
     -- In some cases, we cannot get the player position, so there is no coordinates to share.
     return position ~= nil
@@ -261,8 +272,22 @@ function CombatModule:HaFOnReceivedINeedPets(_, msg, _, sender)
 
     -- Now we find our own position.
     local mapId = C_Map.GetBestMapForUnit("player")
+
+    if issecretvalue and issecretvalue(mapId) then
+        return
+    end
+
     local position = C_Map.GetPlayerMapPosition(mapId, "player")
+
+    if issecretvalue and issecretvalue(position) then
+        return
+    end
+
     local x, y = position:GetXY()
+
+    if issecretvalue and (issecretvalue(x) or issecretvalue(y)) then
+        return
+    end
 
     local message = {
         ["mapId"] = mapId,
@@ -305,6 +330,11 @@ function CombatModule:HaFOnReceivedOfferPets(_, msg, _, sender)
     -- We have received an offer for some pets from a party member.
     -- First we find out which map the user is on and ask the player if they want the pets.
     local mapInfo = C_Map.GetMapInfo(tonumber(message["mapId"]))
+
+    if issecretvalue and issecretvalue(mapInfo) then
+        return
+    end
+
     local dialogMessage = string.format(L["Friend has pets"], sender, mapInfo["name"], table.concat(message["petNames"], ", "))
 
     _G.StaticPopupDialogs[messagePrefixes.OFFER_PETS] = {

--- a/Modules/DB/DBModule.lua
+++ b/Modules/DB/DBModule.lua
@@ -100,7 +100,10 @@ function DBModule:InvalidateMapPinSourcesCache()
 end
 
 local function dataVersion(profile)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(profile) then return 0 end end
+    if issecretvalue and issecretvalue(profile) then
+        return 0
+    end
+
     return profile.dataVersion or 0
 end
 

--- a/Modules/Data/DataModule.lua
+++ b/Modules/Data/DataModule.lua
@@ -44,7 +44,10 @@ function DataModule:HasAnyDataLoaded()
 end
 
 local function DoesPetMatchSourceFilters(speciesId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return false end end
+    if issecretvalue and issecretvalue(speciesId) then
+        return false
+    end
+
     local petSource = DataModule:GetPetSource(speciesId)
 
     if petSource == ZONE then
@@ -65,8 +68,15 @@ local function DoesPetMatchSourceFilters(speciesId)
 end
 
 local function GetMapZoneNames(mapId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapId) then return {} end end
+    if issecretvalue and issecretvalue(mapId) then
+        return {}
+    end
+
     local info = C_Map.GetMapInfo(mapId)
+
+    if issecretvalue and issecretvalue(info) then
+        return
+    end
 
     if not info or info.mapType == Enum.UIMapType.Dungeon then
         return nil
@@ -78,6 +88,11 @@ local function GetMapZoneNames(mapId)
     end
 
     local children = C_Map.GetMapChildrenInfo(mapId)
+
+    if issecretvalue and issecretvalue(children) then
+        return
+    end
+
     if children then
         for _, child in ipairs(children) do
             if child.name then
@@ -90,7 +105,10 @@ local function GetMapZoneNames(mapId)
 end
 
 local function IsPetInMapZone(speciesId, mapZoneNames)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) or issecretvalue(mapZoneNames) then return false end end
+    if issecretvalue and (issecretvalue(speciesId) or issecretvalue(mapZoneNames)) then
+        return false
+    end
+
     local petSource = DataModule:GetPetSource(speciesId)
 
     -- Only filter by source if the pet source is Zone or Pet Battle.
@@ -105,6 +123,10 @@ local function IsPetInMapZone(speciesId, mapZoneNames)
     end
 
     local tooltipSource = select(5, C_PetJournal.GetPetInfoBySpeciesID(speciesId))
+
+    if issecretvalue and issecretvalue(tooltipSource) then
+        return true
+    end
 
     -- If no source is defined (which should never happen), just show the pet rather than hiding it by default.
     if not tooltipSource then
@@ -123,13 +145,21 @@ local function IsPetInMapZone(speciesId, mapZoneNames)
 end
 
 function DataModule:GetPetsInMap(mapId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapId) then return end end
+    if issecretvalue and issecretvalue(mapId) then
+        return
+    end
+
     local allPets = DataModule.PetData[mapId]
     if not allPets then
         return nil
     end
 
     local mapZoneNames = GetMapZoneNames(mapId)
+
+    if issecretvalue and issecretvalue(mapZoneNames) then
+        return
+    end
+
     local pets = {}
 
     for speciesId, locations in pairs(allPets) do
@@ -142,7 +172,10 @@ function DataModule:GetPetsInMap(mapId)
 end
 
 function DataModule:ShouldPetBeShown(speciesId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return false end end
+    if issecretvalue and issecretvalue(speciesId) then
+        return false
+    end
+
     -- Apply source filters first so that later settings can't forget to take them into account
     if not DoesPetMatchSourceFilters(speciesId) then
         return false
@@ -167,6 +200,10 @@ function DataModule:ShouldPetBeShown(speciesId)
 
         local petName = C_PetJournal.GetPetInfoBySpeciesID(speciesId)
 
+        if issecretvalue and issecretvalue(petName) then
+            return false
+        end
+
         -- Since string.find is case sensitive, we convert everything to lowercase first.
         local loweredTextBoxValue = string.lower(profile.mapPinsFilter)
         local loweredPetName = string.lower(petName)
@@ -180,9 +217,22 @@ function DataModule:ShouldPetBeShown(speciesId)
     for _, petId in LibPetJournal:IteratePetIDs() do
         local speciesIdFromJournal = C_PetJournal.GetPetInfoByPetID(petId)
 
+        if issecretvalue and issecretvalue(speciesIdFromJournal) then
+            return false
+        end
+
         if speciesIdFromJournal == speciesId then
             local numCollected, limit = C_PetJournal.GetNumCollectedInfo(speciesId)
+
+            if issecretvalue and (issecretvalue(numCollected) or issecretvalue(limit)) then
+                return false
+            end
+
             local quality = select(5, C_PetJournal.GetPetStats(petId))
+
+            if issecretvalue and issecretvalue(quality) then
+                return false
+            end
 
             if profile.mapPinsToInclude == _BattlePetCompletionist.Enums.MapPinFilter.MISSING then
                 return numCollected < 1
@@ -216,15 +266,26 @@ function DataModule:ShouldPetBeShown(speciesId)
 end
 
 function DataModule:GetOwnedPets(speciesId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return end end
+    if issecretvalue and issecretvalue(speciesId) then
+        return
+    end
+
     local ownedPets = {}
     local anyPetsFound = false
 
     for _, petId in LibPetJournal:IteratePetIDs() do
         local speciesIdFromJournal, _, petLevel = C_PetJournal.GetPetInfoByPetID(petId)
 
+        if issecretvalue and issecretvalue(petId) then
+            return nil
+        end
+
         if speciesIdFromJournal == speciesId then
             local quality = select(5, C_PetJournal.GetPetStats(petId))
+
+            if issecretvalue and issecretvalue(speciesIdFromJournal) then
+                return nil
+            end
 
             table.insert(ownedPets, { petLevel, quality })
             anyPetsFound = true
@@ -240,14 +301,32 @@ end
 
 function DataModule:GetEnemyPetsInBattle()
     local numberOfEnemyPets = C_PetBattles.GetNumPets(Enum.BattlePetOwner.Enemy)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(numberOfEnemyPets) then return {}, {} end end
+
+    if issecretvalue and issecretvalue(numberOfEnemyPets) then
+        return {}, {}
+    end
+
     local foundNotOwnedPets = {}
     local foundOwnedPets = {}
 
     for i = 1, numberOfEnemyPets do
         local speciesId = C_PetBattles.GetPetSpeciesID(Enum.BattlePetOwner.Enemy, i)
+
+        if issecretvalue and issecretvalue(speciesId) then
+            return 0, 0
+        end
+
         local breedQuality = C_PetBattles.GetBreedQuality(Enum.BattlePetOwner.Enemy, i)
+
+        if issecretvalue and issecretvalue(breedQuality) then
+            return 0, 0
+        end
+
         local obtainable = select(11, C_PetJournal.GetPetInfoBySpeciesID(speciesId));
+
+        if issecretvalue and issecretvalue(obtainable) then
+            return 0, 0
+        end
 
         -- In 11.0.0, Blizzard changed the C_PetBattles.GetBreedQuality to be indexed from 0.
         -- However, all other functions related to pet quality is still indexed from 1.
@@ -270,7 +349,10 @@ end
 
 function DataModule:CanWeCapturePets()
     local isNpcControlled = C_PetBattles.IsPlayerNPC(Enum.BattlePetOwner.Enemy)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(isNpcControlled) then return false end end
+
+    if issecretvalue and issecretvalue(isNpcControlled) then
+        return false
+    end
 
     if isNpcControlled == false then
         -- It is a PvP pet battle, you cannot capture pets here.
@@ -279,6 +361,10 @@ function DataModule:CanWeCapturePets()
 
     local isWildBattle = C_PetBattles.IsWildBattle()
 
+    if issecretvalue and issecretvalue(isWildBattle) then
+        return false
+    end
+
     if isWildBattle == false then
         -- It is a quest or something else like that - you cannot capture pets here.
         return false
@@ -286,9 +372,22 @@ function DataModule:CanWeCapturePets()
 
     local numberOfEnemyPets = C_PetBattles.GetNumPets(Enum.BattlePetOwner.Enemy)
 
+    if issecretvalue and issecretvalue(numberOfEnemyPets) then
+        return false
+    end
+
     for i = 1, numberOfEnemyPets do
         local speciesId = C_PetBattles.GetPetSpeciesID(Enum.BattlePetOwner.Enemy, i)
+
+        if issecretvalue and issecretvalue(speciesId) then
+            return false
+        end
+
         local obtainable = select(11, C_PetJournal.GetPetInfoBySpeciesID(speciesId))
+
+        if issecretvalue and issecretvalue(obtainable) then
+            return false
+        end
 
         -- We can end here, but without any captureable pets, so if we see at least one that can be captured, we return true.
         if (obtainable == true) then
@@ -300,7 +399,10 @@ function DataModule:CanWeCapturePets()
 end
 
 function DataModule:GetPetSource(speciesId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return end end
+    if issecretvalue and issecretvalue(speciesId) then
+        return
+    end
+
     local function cleanColorTags(text)
         if not text then return nil end
         return text:gsub("|c%x%x%x%x%x%x%x%x", ""):gsub("|r", "")
@@ -330,6 +432,11 @@ function DataModule:GetPetSource(speciesId)
     end
 
     local tooltipSource = select(5, C_PetJournal.GetPetInfoBySpeciesID(speciesId))
+
+    if issecretvalue and issecretvalue(tooltipSource) then
+        return nil
+    end
+
     if not tooltipSource then return nil end
 
     local cleaned = cleanColorTags(tooltipSource)

--- a/Modules/GoalTracker/GoalTrackerModule.lua
+++ b/Modules/GoalTracker/GoalTrackerModule.lua
@@ -35,8 +35,16 @@ function GoalTrackerModule:UpdateWindow()
     local entries = {}
     if petData then
         for speciesId, _ in pairs(petData) do
-            if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return end end
+            if issecretvalue and issecretvalue(speciesId) then
+                return
+            end
+
             local numCollected = C_PetJournal.GetNumCollectedInfo(speciesId)
+
+            if issecretvalue and issecretvalue(numCollected) then
+                return
+            end
+
             totalSpeciesCount = totalSpeciesCount + 1
 
             if numCollected ~= nil then
@@ -44,6 +52,11 @@ function GoalTrackerModule:UpdateWindow()
                     collectedSpeciesCount = collectedSpeciesCount + 1
                 else
                     local speciesName, speciesIconPath = C_PetJournal.GetPetInfoBySpeciesID(speciesId)
+
+                    if issecretvalue and (issecretvalue(speciesName) or issecretvalue(speciesIconPath)) then
+                        return
+                    end
+
                     table.insert(entries, {speciesId, speciesName, speciesIconPath})
                 end
             end
@@ -180,7 +193,10 @@ function GoalTrackerModule:GetZonePetData()
 end
 
 function GoalTrackerModule:TooltipToSourceTypeIcon(speciesId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return "" end end
+    if issecretvalue and issecretvalue(speciesId) then
+        return ""
+    end
+
     local sourceType = DataModule:GetPetSource(speciesId)
 
     return _BattlePetCompletionist.Constants.PET_SOURCE_ICONS[sourceType] or _BattlePetCompletionist.Constants.PET_SOURCE_ICON_FALLBACK

--- a/Modules/Map/MapModule.lua
+++ b/Modules/Map/MapModule.lua
@@ -29,7 +29,10 @@ MapModule.WorldMapDataProvider = CreateFromMixins(MapCanvasDataProviderMixin)
 function MapModule.WorldMapDataProvider:OnCanvasScaleChanged()
     if InCombatLockdown() then return end
     local map = self:GetMap()
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(map) then return end end
+
+    if issecretvalue and issecretvalue(map) then
+        return
+    end
 
     if not map then
         return
@@ -79,7 +82,10 @@ function MapModule.WorldMapDataProvider:RefreshAllData()
 end
 
 function MapModule.WorldMapDataProvider:LoadMapData(mapId)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapId) then return end end
+    if issecretvalue and issecretvalue(mapId) then
+        return
+    end
+
     self:BeginPinAllocation()
 
     if not self:GetMap() then
@@ -93,7 +99,10 @@ function MapModule.WorldMapDataProvider:LoadMapData(mapId)
     end
 
     local function IsTooCloseToExistingPin(placedPositions, x, y, threshold)
-        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(x) or issecretvalue(y) or issecretvalue(threshold) then return false end end
+        if issecretvalue and (issecretvalue(x) or issecretvalue(y) or issecretvalue(threshold)) then
+            return false
+        end
+
         for _, pos in ipairs(placedPositions) do
             if math.abs(pos[1] - x) < threshold and math.abs(pos[2] - y) < threshold then
                 return true
@@ -112,7 +121,10 @@ function MapModule.WorldMapDataProvider:LoadMapData(mapId)
     end
 
     local function GetMapZoomPercent(map)
-        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(map) then return 0 end end
+        if issecretvalue and issecretvalue(map) then
+            return 0
+        end
+
         if not map or not map.ScrollContainer or not map.ScrollContainer.HasZoomLevels or not map.GetCanvasZoomPercent then
             return 0
         end
@@ -125,6 +137,10 @@ function MapModule.WorldMapDataProvider:LoadMapData(mapId)
     for pet, locations in pairs(petData) do
         if DataModule:ShouldPetBeShown(pet) then
             local _, speciesIcon, petType = C_PetJournal.GetPetInfoBySpeciesID(pet)
+
+            if issecretvalue and issecretvalue() then
+                return
+            end
 
             if petIconType == _BattlePetCompletionist.Enums.MapPinIconType.FAMILY then
                 speciesIcon = _BattlePetCompletionist.Constants.PET_TYPE_ICONS[petType]
@@ -174,7 +190,10 @@ function BattlePetCompletionistWorldMapPinMixin:ShowPinTooltip()
     end
 
     local speciesName, speciesIcon, _, _, tooltipSource = C_PetJournal.GetPetInfoBySpeciesID(self.PetSpeciesID)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesName) or issecretvalue(speciesIcon) or issecretvalue(tooltipSource) then return end end
+
+    if issecretvalue and (issecretvalue(speciesName) or issecretvalue(speciesIcon) or issecretvalue(tooltipSource)) then
+        return
+    end
 
     local ownedPets = DataModule:GetOwnedPets(self.PetSpeciesID)
 
@@ -216,7 +235,11 @@ end
 
 function BattlePetCompletionistWorldMapPinMixin:OnMouseClickAction(button)
     if InCombatLockdown() then return end
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(button) then return end end
+
+    if issecretvalue and issecretvalue(button) then
+        return
+    end
+
     if button ~= "LeftButton" then
         return
     end
@@ -224,8 +247,23 @@ function BattlePetCompletionistWorldMapPinMixin:OnMouseClickAction(button)
     if IsShiftKeyDown() then
         if TomTom and DBModule:GetProfile().tomtomIntegration then
             local x, y = self:GetPosition()
+
+            if issecretvalue and (issecretvalue(x) or issecretvalue(y)) then
+                return
+            end
+
             local mapId = self.MapId
+
+            if issecretvalue and issecretvalue(mapId) then
+                return
+            end
+
             local speciesName = C_PetJournal.GetPetInfoBySpeciesID(self.PetSpeciesID)
+
+            if issecretvalue and issecretvalue(speciesName) then
+                return
+            end
+
             local icon = "Interface\\icons\\inv_pet_achievement_captureawildpet"
 
             local options = {

--- a/Modules/Map/MapTooltip.lua
+++ b/Modules/Map/MapTooltip.lua
@@ -44,7 +44,11 @@ do
 
     function MapModule.Tooltip_Show(anchor, headerLine, collectedLine, sourceLine)
         if InCombatLockdown() then return end
-        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(anchor) or issecretvalue(headerLine) or issecretvalue(collectedLine) or issecretvalue(sourceLine) then return end end
+
+        if issecretvalue and (issecretvalue(anchor) or issecretvalue(headerLine) or issecretvalue(collectedLine) or issecretvalue(sourceLine)) then
+            return
+        end
+
         EnsureFontCached()
 
         if not mapTooltipHeaderFont then
@@ -150,7 +154,10 @@ do
     end
 
     function MapModule.WrapTextWithColor(color, text)
-        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(color) or issecretvalue(text) then return "" end end
+        if issecretvalue and (issecretvalue(color) or issecretvalue(text)) then
+            return ""
+        end
+
         if not color or text == nil then
             return text
         end

--- a/Modules/ObjectiveTracker/ObjectiveTrackerModule.lua
+++ b/Modules/ObjectiveTracker/ObjectiveTrackerModule.lua
@@ -25,7 +25,10 @@ local ZoneModule = BattlePetCompletionist:GetModule("ZoneModule")
 
 -- Sorts by speciesName alphabetically, falling back to speciesId for unnamed entries.
 local function ComparePetsByName(a, b)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(a) or issecretvalue(b) then return false end end
+    if issecretvalue and (issecretvalue(a) or issecretvalue(b)) then
+        return false
+    end
+
     if a.speciesName and b.speciesName then
         return a.speciesName < b.speciesName
     elseif a.speciesName then
@@ -58,12 +61,25 @@ function ObjectiveTrackerModule:GetFilteredPetList()
     local anyMissing = false
     local allPets = {}
     for speciesId in pairs(pets) do
-        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesId) then return end end
+        if issecretvalue and issecretvalue(speciesId) then
+            return
+        end
+
         local numCollected = C_PetJournal.GetNumCollectedInfo(speciesId)
+
+        if issecretvalue and issecretvalue(numCollected) then
+            return nil
+        end
+
         if numCollected == 0 then
             anyMissing = true
         end
         local speciesName = C_PetJournal.GetPetInfoBySpeciesID(speciesId)
+
+        if issecretvalue and issecretvalue(speciesName) then
+            return nil
+        end
+
         tinsert(allPets, { speciesId = speciesId, numCollected = numCollected, speciesName = speciesName })
     end
 

--- a/Modules/ObjectiveTracker/ObjectiveTrackerModule_Retail.lua
+++ b/Modules/ObjectiveTracker/ObjectiveTrackerModule_Retail.lua
@@ -37,12 +37,18 @@ function BattlePetCompletionistObjectiveTrackerMixin:InitModule()
 end
 
 function BattlePetCompletionistObjectiveTrackerMixin:OnEvent(event, ...)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(event) then return end end
+    if issecretvalue and issecretvalue(event) then
+        return
+    end
+
     self:MarkDirty()
 end
 
 function BattlePetCompletionistObjectiveTrackerMixin:OnBlockHeaderClick(block, mouseButton)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(block) or issecretvalue(mouseButton) then return end end
+    if issecretvalue and (issecretvalue(block) or issecretvalue(mouseButton)) then
+        return
+    end
+
     if mouseButton == "LeftButton" then
         if not CollectionsJournal or not CollectionsJournal:IsShown() then
             ToggleCollectionsJournal()
@@ -54,12 +60,21 @@ end
 
 function BattlePetCompletionistObjectiveTrackerMixin:LayoutContents()
     local filteredPets, mapID = ObjectiveTrackerModule:GetFilteredPetList()
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(filteredPets) or issecretvalue(mapID) then return end end
+
+    if issecretvalue and (issecretvalue(filteredPets) or issecretvalue(mapID)) then
+        return
+    end
+
     if not filteredPets then
         return
     end
 
     local mapInfo = C_Map.GetMapInfo(mapID)
+
+    if issecretvalue and issecretvalue(mapInfo) then
+        return
+    end
+
     local zoneName = mapInfo and mapInfo.name or L["current zone"]
 
     local block = self:GetBlock("battlepets")
@@ -73,7 +88,10 @@ function BattlePetCompletionistObjectiveTrackerMixin:LayoutContents()
 end
 
 function BattlePetCompletionistObjectiveTrackerMixin:AddBattlePet(block, petInfo)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(petInfo) or issecretvalue(block) then return end end
+    if issecretvalue and (issecretvalue(petInfo) or issecretvalue(block)) then
+        return
+    end
+
     if not petInfo.speciesName then
         return
     end
@@ -130,7 +148,10 @@ do
     end
 
     function ObjectiveTrackerModule:OnPetEvent(event, ...)
-        if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(event) then return end end
+        if issecretvalue and issecretvalue(event) then
+            return
+        end
+
         if self.Mixin then
             self.Mixin:OnEvent(event, ...)
         end

--- a/Modules/Tooltip/TooltipModule.lua
+++ b/Modules/Tooltip/TooltipModule.lua
@@ -35,9 +35,16 @@ end
 
 function TooltipModule.ModifyPetTip(speciesID)
     if InCombatLockdown() then return end
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(speciesID) then return end end
+
+    if issecretvalue and issecretvalue(speciesID) then
+        return
+    end
+
     local _, _, _, _, source = C_PetJournal.GetPetInfoBySpeciesID(speciesID)
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(source) then return end end
+
+    if issecretvalue and issecretvalue(source) then
+        return
+    end
 
     if source and source ~= "" then
         BattlePetTooltip:AddLine(" ", 1, 1, 1, false)

--- a/Modules/Zone/ZoneModule.lua
+++ b/Modules/Zone/ZoneModule.lua
@@ -40,7 +40,11 @@ function ZoneModule:ResolveZone()
     -- If we wanted to exclude certain sub-zones from being eligible for selection, we could do so using data from
     -- C_Map.GetMapInfo, such as parentMapID.  However, this appears sufficient for now.
     local mapID = C_Map.GetBestMapForUnit("player")
-    if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(mapID) then return end end
+
+    if issecretvalue and issecretvalue(mapID) then
+        return
+    end
+
     -- self.mapID will be nil on first check
     if mapID ~= self.mapID then
         self.mapID = mapID


### PR DESCRIPTION
# Corruption (Taint) Prevention Update

## Changes

* Added issecretvalue() checks on Blizzard's returns @ return
* Added verification of a second condition on an Initialzation to correct a race condition

## Not Yet Done

* Remove on function entry issecretvalue() checks

Note: These are likely not needed, and they can't hurt by being there. So this removal was deferred to @GurliGebis' decision

## Known Issues Fixed

* Pet classes (Warlock/Hunter) going into combat and dismounting causing a corruption/taint (#145)
* Monk issue with "totems"
* As per [this comment](https://github.com/GurliGebis/WoWAddon-BattlePetCompletionist/issues/108#issuecomment-5239308459) issue 108 is addressed

Fixes #145 

