### PR TITLE
ObjectiveTracker: delay SetModuleContainer until after VARIABLES_LOADED to avoid race condition with ObjectiveTrackerManager initialization

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 12.0.7-20260811-2
+* Fix for problem with objective tracker in edit mode.
+
 # 12.0.7-20260811-1
 * Changed ObjectiveTracker to only load for the correct client version, instead of filtering in code.
 

--- a/Modules/ObjectiveTracker/ObjectiveTrackerModule_Retail.lua
+++ b/Modules/ObjectiveTracker/ObjectiveTrackerModule_Retail.lua
@@ -117,7 +117,14 @@ do
     end
 
     function ObjectiveTrackerModule:OnInitialize()
-        self:RegisterEvent("PLAYER_ENTERING_WORLD", "OnPlayerEnteringWorld")
+        EventUtil.ContinueAfterAllEvents(
+            function()
+                self:OnPlayerEnteringWorld()
+            end,
+            "PLAYER_ENTERING_WORLD",
+            "VARIABLES_LOADED"
+        )
+
         self:RegisterEvent("PET_JOURNAL_LIST_UPDATE", "OnPetEvent")
         self:RegisterMessage(_BattlePetCompletionist.Events.ZONE_CHANGE, "OnPetEvent")
     end


### PR DESCRIPTION
This fixes #108