### PR TITLE
added 'a snack attack - ki'clak' to list

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 12.1.0-20260825-1
+* Added "A Stack of Snacks" to activity tracker, provided by JPEscher on github.
+
 # 12.1.0-20260819-1
 * Minor tweaks to the activity tracker.
 

--- a/Modules/AvailableActivity/Data/WorldQuestAchievementData.lua
+++ b/Modules/AvailableActivity/Data/WorldQuestAchievementData.lua
@@ -46,16 +46,19 @@ local BattlePetCompletionist = LibStub("AceAddon-3.0"):GetAddon(addonName)
 local DataModule = BattlePetCompletionist:GetModule("DataModule")
 
 DataModule.ActivitiesData.worldQuestAchievementPetData = {
-    [40869] = { -- Worm Theory
-        petReward = { { petNpcID = 222583, petSpeciesID = 4500, } }, -- Lil' Bonechewer
-    },
-    [40088] = { -- A Champion's Tour: The War Within
-        petReward = { { petNpcID = 223859, petSpeciesID = 4581, } }, -- Ruby-Eyed Stagshell
-    },
     [5449] = { -- Rock Lover
         petReward = { { petNpcID = 45247, petSpeciesID = 265, } } -- Pebble
     },
     [9069] = { -- An Awfully Big Adventure
         petReward = { { petNpcID = 88830, petSpeciesID = 1605, } }, -- Trunks
+    },
+    [40088] = { -- A Champion's Tour: The War Within
+        petReward = { { petNpcID = 223859, petSpeciesID = 4581, } }, -- Ruby-Eyed Stagshell
+    },
+    [40869] = { -- Worm Theory
+        petReward = { { petNpcID = 222583, petSpeciesID = 4500, } }, -- Lil' Bonechewer
+    },
+    [63633] = { -- A Stack of Snacks
+        petReward = { { petNpcID = 270857, petSpeciesID = 5131, } }, -- Ki'clak
     },
 }


### PR DESCRIPTION
wowhead link https://www.wowhead.com/achievement=63633/a-stack-of-snacks#comments
this was missing. new with 12.1